### PR TITLE
31

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,7 +13,7 @@ android {
         applicationId = "com.rama.mako"
         minSdk = 21
         targetSdk = 36
-        versionCode = 30
+        versionCode = 31
         versionName = currentYear + "." + versionCode.toString()
     }
 

--- a/app/src/main/java/com/rama/mako/activities/MainActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/MainActivity.kt
@@ -29,6 +29,7 @@ class MainActivity : CsActivity() {
     private lateinit var clockManager: ClockManager
     private lateinit var batteryManager: BatteryManager
     private lateinit var appListManager: AppListManager
+    private lateinit var appsProvider: AppsProvider
 
     private lateinit var prefs: PrefsManager
 
@@ -62,6 +63,7 @@ class MainActivity : CsActivity() {
         batteryManager.register()
 
         // --- App List ---
+        appsProvider = AppsProvider(this)
         appListManager = AppListManager(this, listView, AppsProvider(this))
         appListManager.setup()
 
@@ -154,17 +156,16 @@ class MainActivity : CsActivity() {
     // --- Open system clock safely ---
     private fun openSystemClock() {
         val packageName = prefs.getClockApp()
-
-        if (!packageName.isNullOrEmpty()) {
-            val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
-            if (launchIntent != null) {
-                startActivity(launchIntent)
-            } else {
-                Toast.makeText(
-                    this,
-                    getString(R.string.unable_launch_app_toast),
-                    Toast.LENGTH_SHORT
-                ).show()
+        if (packageName.isNotEmpty()) {
+            val app = appsProvider.getAll().firstOrNull { it.packageName == packageName }
+            if (app != null) {
+                if (!appsProvider.launch(app)) {
+                    Toast.makeText(
+                        this,
+                        getString(R.string.unable_launch_app_toast),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
             }
         }
     }

--- a/app/src/main/java/com/rama/mako/activities/MainActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/MainActivity.kt
@@ -12,6 +12,7 @@ import android.widget.Toast
 import com.rama.mako.CsActivity
 import com.rama.mako.R
 import com.rama.mako.managers.AppListManager
+import com.rama.mako.managers.AppsProvider
 import com.rama.mako.managers.BatteryManager
 import com.rama.mako.managers.ClockManager
 import com.rama.mako.managers.FontManager
@@ -61,7 +62,7 @@ class MainActivity : CsActivity() {
         batteryManager.register()
 
         // --- App List ---
-        appListManager = AppListManager(this, listView)
+        appListManager = AppListManager(this, listView, AppsProvider(this))
         appListManager.setup()
 
         val emptySpaceDrawer = findViewById<View>(R.id.empty_space_drawer)

--- a/app/src/main/java/com/rama/mako/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/SettingsActivity.kt
@@ -3,6 +3,7 @@ package com.rama.mako.activities
 import android.content.Intent
 import android.os.Bundle
 import android.provider.Settings
+import android.text.Editable
 import android.view.View
 import android.view.View.generateViewId
 import android.view.ViewGroup
@@ -16,6 +17,7 @@ import com.rama.mako.managers.PrefsManager
 import com.rama.mako.managers.PrefsManager.PrefKeys
 import com.rama.mako.widgets.WdButton
 import com.rama.mako.widgets.WdCheckbox
+import android.text.TextWatcher
 
 class SettingsActivity : CsActivity() {
 
@@ -326,6 +328,24 @@ class SettingsActivity : CsActivity() {
         name.setText(groupLabel)
         name.tag = groupId
 
+        val originalText = name.text.toString()
+
+        name.addTextChangedListener(object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {}
+
+            override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+                val currentText = s?.toString() ?: ""
+
+                saveButton.visibility =
+                    if (currentText != originalText && currentText.isNotBlank())
+                        View.VISIBLE
+                    else
+                        View.GONE
+            }
+
+            override fun afterTextChanged(s: Editable?) {}
+        })
+
         saveButton.setOnClickListener {
             val newLabel = name.text.toString().trim()
             if (newLabel.isNotEmpty()) {
@@ -333,6 +353,7 @@ class SettingsActivity : CsActivity() {
                 prefs.setGroupLabel(id, newLabel)
                 Toast.makeText(this, "Label Updated", Toast.LENGTH_SHORT).show()
             }
+            saveButton.visibility = View.GONE
         }
 
         // ------------------- Delete -------------------

--- a/app/src/main/java/com/rama/mako/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/SettingsActivity.kt
@@ -351,7 +351,7 @@ class SettingsActivity : CsActivity() {
 
             val currentGroupId = name.tag as String
 
-            val targetGroups = prefs.getGroupIds()
+            val targetGroups = groupsManager.getGroupIds()
                 .filter { it != currentGroupId }
 
             var selectedGroupId: String? = null

--- a/app/src/main/java/com/rama/mako/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/SettingsActivity.kt
@@ -9,6 +9,7 @@ import android.view.ViewGroup
 import android.widget.*
 import com.rama.mako.CsActivity
 import com.rama.mako.R
+import com.rama.mako.managers.AppsProvider
 import com.rama.mako.managers.FontManager
 import com.rama.mako.managers.GroupsManager
 import com.rama.mako.managers.PrefsManager
@@ -19,7 +20,7 @@ import com.rama.mako.widgets.WdCheckbox
 class SettingsActivity : CsActivity() {
 
     private val prefs by lazy { PrefsManager.getInstance(this) }
-    private val groupsManager by lazy { GroupsManager(this) }
+    private val groupsManager by lazy { GroupsManager(this, AppsProvider(this)) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/rama/mako/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/SettingsActivity.kt
@@ -21,12 +21,14 @@ class SettingsActivity : CsActivity() {
 
     private val prefs by lazy { PrefsManager.getInstance(this) }
     private val groupsManager by lazy { GroupsManager(this, AppsProvider(this)) }
+    private lateinit var appsProvider: AppsProvider
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.view_settings)
 
         applyEdgeToEdgePadding(findViewById(android.R.id.content))
+        appsProvider = AppsProvider(this)
 
         setupBasicButtons()
         setupClockFormat()
@@ -102,23 +104,6 @@ class SettingsActivity : CsActivity() {
         }
     }
 
-    data class AppInfo(val label: String, val packageName: String)
-
-    private fun getLaunchableApps(): List<AppInfo> {
-        val intent = Intent(Intent.ACTION_MAIN, null).apply {
-            addCategory(Intent.CATEGORY_LAUNCHER)
-        }
-
-        return packageManager.queryIntentActivities(intent, 0)
-            .map {
-                AppInfo(
-                    label = it.loadLabel(packageManager).toString(),
-                    packageName = it.activityInfo.packageName
-                )
-            }
-            .sortedBy { it.label.lowercase() }
-    }
-
     private fun showAppPickerDialog() {
         val dialogView = layoutInflater.inflate(R.layout.dialog_pick_clock_app, null)
         FontManager.applyFont(this, dialogView)
@@ -131,7 +116,7 @@ class SettingsActivity : CsActivity() {
         val listView = dialogView.findViewById<ListView>(R.id.app_list)
         val closeBtn = dialogView.findViewById<WdButton>(R.id.close_button)
 
-        val apps = getLaunchableApps()
+        val apps = appsProvider.getAll()
 
         val adapter = object : BaseAdapter() {
             override fun getCount() = apps.size
@@ -149,7 +134,7 @@ class SettingsActivity : CsActivity() {
 
                 view.findViewById<TextView>(R.id.open_app_button).text = app.label
                 view.findViewById<ImageView>(R.id.app_icon).setImageDrawable(
-                    packageManager.getApplicationIcon(app.packageName)
+                    appsProvider.getIcon(app)
                 )
 
                 FontManager.applyFont(parent.context, view)

--- a/app/src/main/java/com/rama/mako/activities/SettingsActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/SettingsActivity.kt
@@ -287,7 +287,7 @@ class SettingsActivity : CsActivity() {
         fun render() {
             container.removeAllViews()
 
-            prefs.getGroupIds().forEach { id ->
+            groupsManager.getGroupIds().forEach { id ->
                 val label = prefs.getGroupLabel(id)
                 addGroupRow(id, label, container, mutableListOf())
             }

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -176,7 +176,8 @@ class AppListManager(
 
     private fun showRenameDialog(app: AppsProvider.AppEntry) {
         val pkg = app.packageName
-        val currentName = getDisplayName(app)
+        val currentName = prefs.getCustomName(app.packageName, app.userHandle)
+            ?: app.label
 
         val view = LayoutInflater.from(context).inflate(R.layout.dialog_rename_app, null)
         FontManager.applyFont(context, view)

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -3,13 +3,10 @@ package com.rama.mako.managers
 import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
-import android.content.pm.PackageManager
-import android.content.pm.ResolveInfo
 import android.content.pm.LauncherApps
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.provider.Settings
-import android.util.TypedValue
 import android.view.LayoutInflater
 import android.view.View
 import android.view.View.generateViewId
@@ -25,11 +22,7 @@ class AppListManager(
     private val listView: ListView,
     private val appsProvider: AppsProvider
 ) {
-
-    private val groupsManager = GroupsManager(context)
     private val prefs = PrefsManager.getInstance(context)
-    private val pm = context.packageManager
-
     private val items = mutableListOf<ListItem>()
     private lateinit var adapter: ArrayAdapter<ListItem>
     private val iconCache = mutableMapOf<String, Drawable>()
@@ -66,7 +59,7 @@ class AppListManager(
 
             val apps = groupedMap[groupId] ?: return@forEach
 
-            val isVisible = groupsManager.isGroupVisible(groupId)
+            val isVisible = prefs.isGroupVisible(groupId)
             if (!isVisible) return@forEach
 
             val label = prefs.getGroupLabel(groupId)
@@ -81,7 +74,7 @@ class AppListManager(
                 )
             }
 
-            val isExpanded = groupsManager.isGroupExpanded(groupId)
+            val isExpanded = prefs.isGroupExpanded(groupId)
             if (!isExpanded) return@forEach
 
             apps.sortedBy { getDisplayName(it).lowercase() }
@@ -122,7 +115,7 @@ class AppListManager(
 
             val apps = groupedMap[groupId] ?: return@forEach
 
-            val isVisible = groupsManager.isGroupVisible(groupId)
+            val isVisible = prefs.isGroupVisible(groupId)
             if (!isVisible) return@forEach
 
             // Filter apps
@@ -144,7 +137,7 @@ class AppListManager(
 
             }
 
-            val isExpanded = groupsManager.isGroupExpanded(groupId)
+            val isExpanded = prefs.isGroupExpanded(groupId)
             if (!isExpanded) return@forEach
 
             matchedApps
@@ -329,7 +322,7 @@ class AppListManager(
                         val groupId = item.id
                         val groupName = item.title
 
-                        val isExpanded = groupsManager.isGroupExpanded(groupId)
+                        val isExpanded = prefs.isGroupExpanded(groupId)
 
                         text.text =
                             (if (isExpanded) "[-] " else "[+] ") + groupName.uppercase()
@@ -339,8 +332,8 @@ class AppListManager(
                         if (prefs.hasCollapsibleGroups()) {
 
                             view.setOnClickListener {
-                                val currently = groupsManager.isGroupExpanded(groupId)
-                                groupsManager.setGroupExpanded(groupId, !currently)
+                                val currently = prefs.isGroupExpanded(groupId)
+                                prefs.setGroupExpanded(groupId, !currently)
                                 refresh()
                             }
                         }
@@ -411,10 +404,3 @@ class AppListManager(
         data class App(val info: AppsProvider.AppEntry) : ListItem()
     }
 }
-
-// --- PrefsManager extension for app custom names ---
-fun PrefsManager.getCustomName(pkg: String): String? = prefs.getString(pkg, null)
-fun PrefsManager.setCustomName(pkg: String, name: String) =
-    prefs.edit().putString(pkg, name).apply()
-
-fun PrefsManager.clearCustomName(pkg: String) = prefs.edit().remove(pkg).apply()

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -83,7 +83,11 @@ class AppListManager(
 
     private fun getDisplayName(app: AppsProvider.AppEntry): String {
         val custom = prefs.getCustomName(app.packageName, app.userHandle)
-        return if (app.isWorkProfile) "[W] ${custom ?: app.label}" else custom ?: app.label
+        return if (custom != null) {
+            if (app.isWorkProfile) "[${app.profileInitial}] $custom" else custom
+        } else {
+            app.displayLabel
+        }
     }
 
     fun filter(query: String) {

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -3,7 +3,6 @@ package com.rama.mako.managers
 import android.app.AlertDialog
 import android.content.Context
 import android.content.Intent
-import android.content.pm.LauncherApps
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.provider.Settings
@@ -143,25 +142,6 @@ class AppListManager(
         items.clear()
         items.addAll(filteredItems)
         adapter.notifyDataSetChanged()
-    }
-
-    private fun launchApp(app: AppsProvider.AppEntry) {
-        val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
-        try {
-            launcherApps.startMainActivity(
-                app.activityInfo.componentName,
-                app.userHandle,
-                null,
-                null
-            )
-        } catch (e: Exception) {
-            Toast.makeText(
-                context,
-                context.getString(R.string.unable_launch_app_toast),
-                Toast.LENGTH_SHORT
-            ).show()
-            refresh()
-        }
     }
 
     private fun openAppSettings(pkg: String) {
@@ -355,7 +335,16 @@ class AppListManager(
                             }
                             icon.setImageDrawable(drawable)
                             icon.visibility = View.VISIBLE
-                            icon.setOnClickListener { launchApp(app) }
+                            icon.setOnClickListener {
+                                if (!appsProvider.launch(app)) {
+                                    Toast.makeText(
+                                        context,
+                                        context.getString(R.string.unable_launch_app_toast),
+                                        Toast.LENGTH_SHORT
+                                    ).show()
+                                    refresh()
+                                }
+                            }
                             icon.setOnLongClickListener { showContextMenu(it, app); true }
                         } else {
                             icon.visibility = View.GONE
@@ -365,8 +354,26 @@ class AppListManager(
 
                         label.text = getDisplayName(app)
 
-                        label.setOnClickListener { launchApp(app) }
-                        emptySpace.setOnClickListener { launchApp(app) }
+                        label.setOnClickListener {
+                            if (!appsProvider.launch(app)) {
+                                Toast.makeText(
+                                    context,
+                                    context.getString(R.string.unable_launch_app_toast),
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                                refresh()
+                            }
+                        }
+                        emptySpace.setOnClickListener {
+                            if (!appsProvider.launch(app)) {
+                                Toast.makeText(
+                                    context,
+                                    context.getString(R.string.unable_launch_app_toast),
+                                    Toast.LENGTH_SHORT
+                                ).show()
+                                refresh()
+                            }
+                        }
 
                         label.setOnLongClickListener { showContextMenu(it, app); true }
                         emptySpace.setOnLongClickListener {

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -81,15 +81,9 @@ class AppListManager(
                 .forEach { items.add(ListItem.App(it)) }
         }
     }
-// TODO Remove
-//    private fun sanitizeSystemLabel(raw: String): String =
-//        raw.replace(Regex("[\\p{So}\\p{Cn}]"), "")
-//            .replace(Regex("[!?.]{2,}"), "")
-//            .replace(Regex("\\s+"), " ")
-//            .trim()
 
     private fun getDisplayName(app: AppsProvider.AppEntry): String {
-        return prefs.getCustomName(app.packageName, app.userHandle) ?: app.label
+        return prefs.getCustomName(app.packageName, app.userHandle) ?: app.displayLabel
     }
 
     fun filter(query: String) {

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -46,7 +46,7 @@ class AppListManager(
 
         // Map apps by groupId (NOT label)
         val groupedMap = allApps.groupBy { app ->
-            prefs.getAppGroupId(app.packageName) ?: PrefsManager.SystemIds.UNGROUPED
+            prefs.getAppGroupId(app.packageName, app.userHandle) ?: PrefsManager.SystemIds.UNGROUPED
         }
 
         items.clear()
@@ -89,7 +89,7 @@ class AppListManager(
 //            .trim()
 
     private fun getDisplayName(app: AppsProvider.AppEntry): String {
-        return prefs.getCustomName(app.packageName) ?: app.label
+        return prefs.getCustomName(app.packageName, app.userHandle) ?: app.label
     }
 
     fun filter(query: String) {
@@ -104,7 +104,7 @@ class AppListManager(
 
         // Group by ID
         val groupedMap = allApps.groupBy { app ->
-            prefs.getAppGroupId(app.packageName) ?: PrefsManager.SystemIds.UNGROUPED
+            prefs.getAppGroupId(app.packageName, app.userHandle) ?: PrefsManager.SystemIds.UNGROUPED
         }
 
         // Handle unknown groups (apps pointing to deleted groups)
@@ -197,13 +197,13 @@ class AppListManager(
 
         yesButton.setOnClickListener {
             input.text.toString().trim().takeIf { it.isNotEmpty() }
-                ?.let { prefs.setCustomName(pkg, it) }
+                ?.let { prefs.setCustomName(pkg, app.userHandle, it) }
             refresh()
             dialog.dismiss()
         }
 
         resetButton.setOnClickListener {
-            prefs.clearCustomName(pkg)
+            prefs.clearCustomName(pkg, app.userHandle)
             refresh()
             dialog.dismiss()
         }
@@ -231,7 +231,8 @@ class AppListManager(
 
             val radioGroup = RadioGroup(context)
 
-            val currentGroupId = prefs.getAppGroupId(pkg) ?: PrefsManager.SystemIds.UNGROUPED
+            val currentGroupId =
+                prefs.getAppGroupId(pkg, app.userHandle) ?: PrefsManager.SystemIds.UNGROUPED
 
             // All group IDs (include ungrouped)
             val groupIds = prefs.getGroupIds().toMutableList()
@@ -255,7 +256,7 @@ class AppListManager(
                 FontManager.applyFont(context, radio)
 
                 radio.setOnClickListener {
-                    prefs.setAppGroupId(pkg, groupId)
+                    prefs.setAppGroupId(pkg, app.userHandle, groupId)
                     refresh()
                     dialog.dismiss()
                 }

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -330,9 +330,8 @@ class AppListManager(
                         val showIcons = prefs.hasIconsVisible()
 
                         if (showIcons) {
-                            val drawable = iconCache.getOrPut(pkg) {
-                                app.activityInfo.getIcon(context.resources.displayMetrics.densityDpi)
-                            }
+                            val drawable = appsProvider.getIcon(app)
+
                             icon.setImageDrawable(drawable)
                             icon.visibility = View.VISIBLE
                             icon.setOnClickListener {

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -83,7 +83,8 @@ class AppListManager(
     }
 
     private fun getDisplayName(app: AppsProvider.AppEntry): String {
-        return prefs.getCustomName(app.packageName, app.userHandle) ?: app.displayLabel
+        val custom = prefs.getCustomName(app.packageName, app.userHandle)
+        return if (app.isWorkProfile) "[W] ${custom ?: app.label}" else custom ?: app.label
     }
 
     fun filter(query: String) {

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.content.pm.ResolveInfo
+import android.content.pm.LauncherApps
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.provider.Settings
@@ -21,7 +22,8 @@ import com.rama.mako.widgets.WdButton
 
 class AppListManager(
     private val context: Context,
-    private val listView: ListView
+    private val listView: ListView,
+    private val appsProvider: AppsProvider
 ) {
 
     private val groupsManager = GroupsManager(context)
@@ -44,18 +46,14 @@ class AppListManager(
     }
 
     private fun buildItems() {
-        val intent = Intent(Intent.ACTION_MAIN).apply {
-            addCategory(Intent.CATEGORY_LAUNCHER)
-        }
-
-        val allApps = pm.queryIntentActivities(intent, 0)
+        val allApps = appsProvider.getAll()
 
         // Get all known group IDs
         val groupIds = prefs.getGroupIds().toMutableSet()
 
         // Map apps by groupId (NOT label)
         val groupedMap = allApps.groupBy { app ->
-            prefs.getAppGroupId(app.activityInfo.packageName) ?: PrefsManager.SystemIds.UNGROUPED
+            prefs.getAppGroupId(app.packageName) ?: PrefsManager.SystemIds.UNGROUPED
         }
 
         items.clear()
@@ -90,16 +88,15 @@ class AppListManager(
                 .forEach { items.add(ListItem.App(it)) }
         }
     }
+// TODO Remove
+//    private fun sanitizeSystemLabel(raw: String): String =
+//        raw.replace(Regex("[\\p{So}\\p{Cn}]"), "")
+//            .replace(Regex("[!?.]{2,}"), "")
+//            .replace(Regex("\\s+"), " ")
+//            .trim()
 
-    private fun sanitizeSystemLabel(raw: String): String =
-        raw.replace(Regex("[\\p{So}\\p{Cn}]"), "")
-            .replace(Regex("[!?.]{2,}"), "")
-            .replace(Regex("\\s+"), " ")
-            .trim()
-
-    private fun getDisplayName(app: ResolveInfo): String {
-        val pkg = app.activityInfo.packageName
-        return prefs.getCustomName(pkg) ?: sanitizeSystemLabel(app.loadLabel(pm).toString())
+    private fun getDisplayName(app: AppsProvider.AppEntry): String {
+        return prefs.getCustomName(app.packageName) ?: app.label
     }
 
     fun filter(query: String) {
@@ -107,18 +104,14 @@ class AppListManager(
 
         val filteredItems = mutableListOf<ListItem>()
 
-        val intent = Intent(Intent.ACTION_MAIN).apply {
-            addCategory(Intent.CATEGORY_LAUNCHER)
-        }
-
-        val allApps = pm.queryIntentActivities(intent, 0)
+        val allApps = appsProvider.getAll()
 
         // All known group IDs
         val groupIds = prefs.getGroupIds().toMutableSet()
 
         // Group by ID
         val groupedMap = allApps.groupBy { app ->
-            prefs.getAppGroupId(app.activityInfo.packageName) ?: PrefsManager.SystemIds.UNGROUPED
+            prefs.getAppGroupId(app.packageName) ?: PrefsManager.SystemIds.UNGROUPED
         }
 
         // Handle unknown groups (apps pointing to deleted groups)
@@ -164,11 +157,16 @@ class AppListManager(
         adapter.notifyDataSetChanged()
     }
 
-    private fun launchApp(pkg: String) {
-        pm.getLaunchIntentForPackage(pkg)?.let {
-            it.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            context.startActivity(it)
-        } ?: run {
+    private fun launchApp(app: AppsProvider.AppEntry) {
+        val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+        try {
+            launcherApps.startMainActivity(
+                app.activityInfo.componentName,
+                app.userHandle,
+                null,
+                null
+            )
+        } catch (e: Exception) {
             Toast.makeText(
                 context,
                 context.getString(R.string.unable_launch_app_toast),
@@ -188,9 +186,9 @@ class AppListManager(
         )
     }
 
-    private fun showRenameDialog(app: ResolveInfo) {
-        val pkg = app.activityInfo.packageName
-        val currentName = prefs.getCustomName(pkg) ?: getDisplayName(app)
+    private fun showRenameDialog(app: AppsProvider.AppEntry) {
+        val pkg = app.packageName
+        val currentName = getDisplayName(app)
 
         val view = LayoutInflater.from(context).inflate(R.layout.dialog_rename_app, null)
         FontManager.applyFont(context, view)
@@ -221,8 +219,8 @@ class AppListManager(
         dialog.show()
     }
 
-    private fun showGroupsDialog(app: ResolveInfo) {
-        val pkg = app.activityInfo.packageName
+    private fun showGroupsDialog(app: AppsProvider.AppEntry) {
+        val pkg = app.packageName
 
         val view = View.inflate(context, R.layout.dialog_groups_add, null)
         FontManager.applyFont(context, view)
@@ -282,8 +280,8 @@ class AppListManager(
         dialog.show()
     }
 
-    private fun showContextMenu(anchor: View, app: ResolveInfo) {
-        val pkg = app.activityInfo.packageName
+    private fun showContextMenu(anchor: View, app: AppsProvider.AppEntry) {
+        val pkg = app.packageName
         val popup = PopupMenu(context, anchor)
         popup.menuInflater.inflate(R.menu.app_context_menu, popup.menu)
         popup.setOnMenuItemClickListener { item ->
@@ -354,7 +352,7 @@ class AppListManager(
                         val view =
                             convertView ?: View.inflate(context, R.layout.list_item_app, null)
                         val app = item.info
-                        val pkg = app.activityInfo.packageName
+                        val pkg = app.packageName
                         val label = view.findViewById<TextView>(R.id.open_app_button)
                         val emptySpace = view.findViewById<View>(R.id.empty_space)
 
@@ -363,11 +361,11 @@ class AppListManager(
 
                         if (showIcons) {
                             val drawable = iconCache.getOrPut(pkg) {
-                                app.loadIcon(pm)
+                                app.activityInfo.getIcon(context.resources.displayMetrics.densityDpi)
                             }
                             icon.setImageDrawable(drawable)
                             icon.visibility = View.VISIBLE
-                            icon.setOnClickListener { launchApp(pkg) }
+                            icon.setOnClickListener { launchApp(app) }
                             icon.setOnLongClickListener { showContextMenu(it, app); true }
                         } else {
                             icon.visibility = View.GONE
@@ -377,8 +375,8 @@ class AppListManager(
 
                         label.text = getDisplayName(app)
 
-                        label.setOnClickListener { launchApp(pkg) }
-                        emptySpace.setOnClickListener { launchApp(pkg) }
+                        label.setOnClickListener { launchApp(app) }
+                        emptySpace.setOnClickListener { launchApp(app) }
 
                         label.setOnLongClickListener { showContextMenu(it, app); true }
                         emptySpace.setOnLongClickListener {
@@ -409,13 +407,8 @@ class AppListManager(
     }
 
     private sealed class ListItem {
-
-        data class Header(
-            val id: String,
-            val title: String
-        ) : ListItem()
-
-        data class App(val info: ResolveInfo) : ListItem()
+        data class Header(val id: String, val title: String) : ListItem()
+        data class App(val info: AppsProvider.AppEntry) : ListItem()
     }
 }
 

--- a/app/src/main/java/com/rama/mako/managers/AppsProvider.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppsProvider.kt
@@ -13,27 +13,28 @@ class AppsProvider(private val context: Context) {
         val packageName: String,
         val label: String,
         val userHandle: UserHandle,
-        val activityInfo: LauncherActivityInfo
+        val activityInfo: LauncherActivityInfo,
+        val profileInitial: String?
     ) {
         val isWorkProfile: Boolean = userHandle.hashCode() != 0
-        val displayLabel: String = if (isWorkProfile) "[W] $label" else label
+        val displayLabel: String = if (isWorkProfile) "[$profileInitial] $label" else label
     }
 
     private val launcherApps =
         context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
     private val iconCache = mutableMapOf<String, Drawable>()
+    private val userManager = context.getSystemService(Context.USER_SERVICE) as UserManager
 
     fun getAll(): List<AppEntry> {
-        val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
-        val userManager = context.getSystemService(Context.USER_SERVICE) as UserManager
-
         return userManager.userProfiles.flatMap { userHandle ->
+            val profileInitial = getProfileInitial(userHandle)
             launcherApps.getActivityList(null, userHandle).map { info ->
                 AppEntry(
                     packageName = info.applicationInfo.packageName,
                     label = info.label.toString(),
                     userHandle = userHandle,
-                    activityInfo = info
+                    activityInfo = info,
+                    profileInitial = profileInitial
                 )
             }
         }
@@ -58,5 +59,14 @@ class AppsProvider(private val context: Context) {
         return iconCache.getOrPut(key) {
             app.activityInfo.getIcon(context.resources.displayMetrics.densityDpi)
         }
+    }
+
+    private fun getProfileInitial(userHandle: UserHandle): String? {
+        if (userHandle.hashCode() == 0) return null
+        return context.packageManager.getUserBadgedLabel("", userHandle).toString()
+            .trim()
+            .firstOrNull()
+            ?.uppercase()
+            ?: "E"
     }
 }

--- a/app/src/main/java/com/rama/mako/managers/AppsProvider.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppsProvider.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.pm.LauncherActivityInfo
 import android.os.UserHandle
 import android.content.pm.LauncherApps
+import android.graphics.drawable.Drawable
 import android.os.UserManager
 
 class AppsProvider(private val context: Context) {
@@ -20,6 +21,7 @@ class AppsProvider(private val context: Context) {
 
     private val launcherApps =
         context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+    private val iconCache = mutableMapOf<String, Drawable>()
 
     fun getAll(): List<AppEntry> {
         val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
@@ -48,6 +50,13 @@ class AppsProvider(private val context: Context) {
             true
         } catch (e: Exception) {
             false
+        }
+    }
+
+    fun getIcon(app: AppEntry): Drawable {
+        val key = "${app.packageName}:${app.userHandle.hashCode()}"
+        return iconCache.getOrPut(key) {
+            app.activityInfo.getIcon(context.resources.displayMetrics.densityDpi)
         }
     }
 }

--- a/app/src/main/java/com/rama/mako/managers/AppsProvider.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppsProvider.kt
@@ -13,7 +13,10 @@ class AppsProvider(private val context: Context) {
         val label: String,
         val userHandle: UserHandle,
         val activityInfo: LauncherActivityInfo
-    )
+    ) {
+        val isWorkProfile: Boolean = userHandle.hashCode() != 0
+        val displayLabel: String = if (isWorkProfile) "[W] $label" else label
+    }
 
     fun getAll(): List<AppEntry> {
         val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps

--- a/app/src/main/java/com/rama/mako/managers/AppsProvider.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppsProvider.kt
@@ -1,0 +1,33 @@
+package com.rama.mako.managers
+
+import android.content.Context
+import android.content.pm.LauncherActivityInfo
+import android.os.UserHandle
+import android.content.pm.LauncherApps
+import android.os.UserManager
+
+class AppsProvider(private val context: Context) {
+
+    data class AppEntry(
+        val packageName: String,
+        val label: String,
+        val userHandle: UserHandle,
+        val activityInfo: LauncherActivityInfo
+    )
+
+    fun getAll(): List<AppEntry> {
+        val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+        val userManager = context.getSystemService(Context.USER_SERVICE) as UserManager
+
+        return userManager.userProfiles.flatMap { userHandle ->
+            launcherApps.getActivityList(null, userHandle).map { info ->
+                AppEntry(
+                    packageName = info.applicationInfo.packageName,
+                    label = info.label.toString(),
+                    userHandle = userHandle,
+                    activityInfo = info
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/rama/mako/managers/AppsProvider.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppsProvider.kt
@@ -18,6 +18,9 @@ class AppsProvider(private val context: Context) {
         val displayLabel: String = if (isWorkProfile) "[W] $label" else label
     }
 
+    private val launcherApps =
+        context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
+
     fun getAll(): List<AppEntry> {
         val launcherApps = context.getSystemService(Context.LAUNCHER_APPS_SERVICE) as LauncherApps
         val userManager = context.getSystemService(Context.USER_SERVICE) as UserManager
@@ -31,6 +34,20 @@ class AppsProvider(private val context: Context) {
                     activityInfo = info
                 )
             }
+        }
+    }
+
+    fun launch(app: AppEntry): Boolean {
+        return try {
+            launcherApps.startMainActivity(
+                app.activityInfo.componentName,
+                app.userHandle,
+                null,
+                null
+            )
+            true
+        } catch (e: Exception) {
+            false
         }
     }
 }

--- a/app/src/main/java/com/rama/mako/managers/GroupManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/GroupManager.kt
@@ -33,8 +33,8 @@ class GroupsManager(
     fun deleteGroup(groupId: String, newGroupId: String?) {
         val allApps = appsProvider.getAll()
         allApps.forEach { app ->
-            if (prefs.getAppGroupId(app.packageName) == groupId) {
-                prefs.setAppGroupId(app.packageName, newGroupId)
+            if (prefs.getAppGroupId(app.packageName, app.userHandle) == groupId) {
+                prefs.setAppGroupId(app.packageName, app.userHandle, newGroupId)
             }
         }
 

--- a/app/src/main/java/com/rama/mako/managers/GroupManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/GroupManager.kt
@@ -3,7 +3,10 @@ package com.rama.mako.managers
 import android.content.Context
 import com.rama.mako.utils.IdUtils
 
-class GroupsManager(private val context: Context) {
+class GroupsManager(
+    context: Context,
+    private val appsProvider: AppsProvider
+) {
 
     private val prefs = PrefsManager.getInstance(context)
 
@@ -28,9 +31,10 @@ class GroupsManager(private val context: Context) {
     }
 
     fun deleteGroup(groupId: String, newGroupId: String?) {
-        getAllApps().forEach { pkg ->
-            if (prefs.getAppGroupId(pkg) == groupId) {
-                prefs.setAppGroupId(pkg, newGroupId)
+        val allApps = appsProvider.getAll()
+        allApps.forEach { app ->
+            if (prefs.getAppGroupId(app.packageName) == groupId) {
+                prefs.setAppGroupId(app.packageName, newGroupId)
             }
         }
 
@@ -52,32 +56,5 @@ class GroupsManager(private val context: Context) {
         }
 
         return label
-    }
-
-    // ------------------- Visibility -------------------
-
-    fun isGroupVisible(groupId: String) =
-        prefs.isGroupVisible(groupId)
-
-    fun isGroupExpanded(groupId: String) =
-        prefs.isGroupExpanded(groupId)
-
-    fun setGroupVisible(groupId: String, visible: Boolean) =
-        prefs.setGroupVisible(groupId, visible)
-
-    fun setGroupExpanded(groupId: String, expanded: Boolean) =
-        prefs.setGroupExpanded(groupId, expanded)
-
-    // ------------------- Helpers -------------------
-
-    private fun getAllApps(): List<String> {
-        val pm = context.packageManager
-
-        val intent = android.content.Intent(android.content.Intent.ACTION_MAIN).apply {
-            addCategory(android.content.Intent.CATEGORY_LAUNCHER)
-        }
-
-        return pm.queryIntentActivities(intent, 0)
-            .map { it.activityInfo.packageName }
     }
 }

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -3,6 +3,7 @@ package com.rama.mako.managers
 import android.content.Context
 import android.content.SharedPreferences
 import android.net.Uri
+import android.os.UserHandle
 import android.util.Log
 import com.rama.mako.utils.IdUtils
 import org.json.JSONObject
@@ -49,8 +50,17 @@ class PrefsManager private constructor(context: Context) {
         const val CLOCK_APP = "clock:app"
         const val FONT_STYLE = "font:style"
 
-        fun APP_GROUP_ID(pkg: String) = "app:$pkg:group_id"
-        fun APP_CUSTOM_LABEL(pkg: String) = "app:$pkg:custom_label"
+        fun appKey(pkg: String, userHandle: UserHandle): String {
+            val userId = userHandle.hashCode()
+            return if (userId == 0) "app:$pkg" else "app:$pkg:work"
+        }
+
+        fun APP_GROUP_ID(pkg: String, userHandle: UserHandle) =
+            "${appKey(pkg, userHandle)}:group_id"
+
+        fun APP_CUSTOM_LABEL(pkg: String, userHandle: UserHandle) =
+            "${appKey(pkg, userHandle)}:custom_label"
+
         fun GROUP_LABEL(id: String) = "group:$id:label"
         fun GROUP_VISIBLE(id: String) = "group:$id:visible"
         fun GROUP_EXPANDED(id: String) = "group:$id:expanded"
@@ -128,20 +138,19 @@ class PrefsManager private constructor(context: Context) {
 
     // --- APP GROUP MAPPING ---
 
-    //    fun getAppGroupId(pkg: String): String? =
-//        getString(PrefKeys.APP_GROUP_ID(pkg), "").takeIf { it.isNotEmpty() }
-    fun getAppGroupId(pkg: String): String {
-        return prefs.getString(PrefKeys.APP_GROUP_ID(pkg), null)
+    fun getAppGroupId(pkg: String, userHandle: UserHandle): String {
+        return prefs.getString(PrefKeys.APP_GROUP_ID(pkg, userHandle), null)
             ?: SystemIds.UNGROUPED.also {
-                prefs.edit().putString(PrefKeys.APP_GROUP_ID(pkg), it).apply()
+                prefs.edit().putString(PrefKeys.APP_GROUP_ID(pkg, userHandle), it).apply()
             }
     }
 
-    fun setAppGroupId(pkg: String, groupId: String?) {
+    fun setAppGroupId(pkg: String, userHandle: UserHandle, groupId: String?) {
+        val key = PrefKeys.APP_GROUP_ID(pkg, userHandle)
         if (groupId != null) {
-            setString(PrefKeys.APP_GROUP_ID(pkg), groupId)
+            prefs.edit().putString(key, groupId).apply()
         } else {
-            setString(PrefKeys.APP_GROUP_ID(pkg), "")
+            prefs.edit().remove(key).apply()
         }
     }
 
@@ -242,14 +251,15 @@ class PrefsManager private constructor(context: Context) {
     fun setString(key: String, value: String) =
         prefs.edit().putString(key, value).apply()
 
-    fun getCustomName(pkg: String): String? =
-        prefs.getString(PrefKeys.APP_CUSTOM_LABEL(pkg), null)?.takeIf { it.isNotEmpty() }
+    fun getCustomName(pkg: String, userHandle: UserHandle): String? =
+        prefs.getString(PrefKeys.APP_CUSTOM_LABEL(pkg, userHandle), null)
+            ?.takeIf { it.isNotEmpty() }
 
-    fun setCustomName(pkg: String, name: String) =
-        prefs.edit().putString(PrefKeys.APP_CUSTOM_LABEL(pkg), name).apply()
+    fun setCustomName(pkg: String, userHandle: UserHandle, name: String) =
+        prefs.edit().putString(PrefKeys.APP_CUSTOM_LABEL(pkg, userHandle), name).apply()
 
-    fun clearCustomName(pkg: String) =
-        prefs.edit().remove(PrefKeys.APP_CUSTOM_LABEL(pkg)).apply()
+    fun clearCustomName(pkg: String, userHandle: UserHandle) =
+        prefs.edit().remove(PrefKeys.APP_CUSTOM_LABEL(pkg, userHandle)).apply()
 
     // Core builder
 

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -52,7 +52,7 @@ class PrefsManager private constructor(context: Context) {
 
         fun appKey(pkg: String, userHandle: UserHandle): String {
             val userId = userHandle.hashCode()
-            return if (userId == 0) "app:$pkg" else "app:$pkg:work"
+            return if (userId == 0) "app:$pkg" else "app:$pkg:profile_$userId"
         }
 
         fun APP_GROUP_ID(pkg: String, userHandle: UserHandle) =

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -50,7 +50,7 @@ class PrefsManager private constructor(context: Context) {
         const val FONT_STYLE = "font:style"
 
         fun APP_GROUP_ID(pkg: String) = "app:$pkg:group_id"
-        fun APP_CUSTOM_NAME(pkg: String) = "app:$pkg:custom_label"
+        fun APP_CUSTOM_LABEL(pkg: String) = "app:$pkg:custom_label"
         fun GROUP_LABEL(id: String) = "group:$id:label"
         fun GROUP_VISIBLE(id: String) = "group:$id:visible"
         fun GROUP_EXPANDED(id: String) = "group:$id:expanded"
@@ -243,13 +243,13 @@ class PrefsManager private constructor(context: Context) {
         prefs.edit().putString(key, value).apply()
 
     fun getCustomName(pkg: String): String? =
-        prefs.getString(PrefKeys.APP_CUSTOM_NAME(pkg), null)?.takeIf { it.isNotEmpty() }
+        prefs.getString(PrefKeys.APP_CUSTOM_LABEL(pkg), null)?.takeIf { it.isNotEmpty() }
 
     fun setCustomName(pkg: String, name: String) =
-        prefs.edit().putString(PrefKeys.APP_CUSTOM_NAME(pkg), name).apply()
+        prefs.edit().putString(PrefKeys.APP_CUSTOM_LABEL(pkg), name).apply()
 
     fun clearCustomName(pkg: String) =
-        prefs.edit().remove(PrefKeys.APP_CUSTOM_NAME(pkg)).apply()
+        prefs.edit().remove(PrefKeys.APP_CUSTOM_LABEL(pkg)).apply()
 
     // Core builder
 

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -50,6 +50,7 @@ class PrefsManager private constructor(context: Context) {
         const val FONT_STYLE = "font:style"
 
         fun APP_GROUP_ID(pkg: String) = "app:$pkg:group_id"
+        fun APP_CUSTOM_NAME(pkg: String) = "app:$pkg:custom_label"
         fun GROUP_LABEL(id: String) = "group:$id:label"
         fun GROUP_VISIBLE(id: String) = "group:$id:visible"
         fun GROUP_EXPANDED(id: String) = "group:$id:expanded"
@@ -240,6 +241,15 @@ class PrefsManager private constructor(context: Context) {
 
     fun setString(key: String, value: String) =
         prefs.edit().putString(key, value).apply()
+
+    fun getCustomName(pkg: String): String? =
+        prefs.getString(PrefKeys.APP_CUSTOM_NAME(pkg), null)?.takeIf { it.isNotEmpty() }
+
+    fun setCustomName(pkg: String, name: String) =
+        prefs.edit().putString(PrefKeys.APP_CUSTOM_NAME(pkg), name).apply()
+
+    fun clearCustomName(pkg: String) =
+        prefs.edit().remove(PrefKeys.APP_CUSTOM_NAME(pkg)).apply()
 
     // Core builder
 

--- a/app/src/main/res/layout/dialog_groups_delete.xml
+++ b/app/src/main/res/layout/dialog_groups_delete.xml
@@ -11,9 +11,19 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8sp"
-        android:textSize="18sp"
+        android:textSize="32sp"
         android:textColor="@color/foreground_color"
         android:text="@string/delete_group_title"
+        android:gravity="center"
+        android:textStyle="bold" />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8sp"
+        android:textSize="18sp"
+        android:textColor="@color/foreground_color"
+        android:text="@string/delete_group_disclaimer"
         android:gravity="center"
         android:textStyle="bold" />
 

--- a/app/src/main/res/layout/list_item_group.xml
+++ b/app/src/main/res/layout/list_item_group.xml
@@ -35,6 +35,7 @@
         android:layout_height="wrap_content" />
 
     <FrameLayout
+        android:visibility="gone"
         android:id="@+id/save_changes_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,7 +118,8 @@
     <string name="search_apps_header">Search apps</string>
 
     <!-- Dialog :: Delete Group -->
-    <string name="delete_group_title">Are you sure you want to delete this group?\nYour apps will go to the following group.</string>
+    <string name="delete_group_title">Are you sure you want to delete this group?</string>
+    <string name="delete_group_disclaimer">Your apps will go to the following group.</string>
     <string name="delete_group">Delete group</string>
 
     <!-- Dialog :: Pick Clock App -->

--- a/readme.md
+++ b/readme.md
@@ -70,6 +70,12 @@ No network access is required.
 **Mako** is Free Software. You are free to use, study, share, and improve it under the terms of the
 **GNU General Public License v3** or later.
 
+## QA
+
+- Pixel 8 Pro / Android 16 :: 2026
+- Pixel 6 / Graphene OS :: 2026
+- Samsung On 5 / Android 6 :: 2015
+
 ---
 
 ## Acknowledgements


### PR DESCRIPTION
## What's new

**Work profile support**
Apps from secondary profiles now show up in the launcher. Each profile gets its own label prefix (e.g. `[W] Gmail`) based on the profile name, so you can always tell them apart. Group assignments and custom names are saved independently per profile.

**More reliable data storage**
Rewriting how settings and group data are stored from the ground up. All preference keys are now structured and namespaced (e.g. `app:com.example:group_id`), which prevents silent data collisions that were causing hidden bugs.

**Bug fixes**
- Checkboxes in Settings no longer reset to unchecked when navigating to About and back
- Renaming the Default group now reflects correctly everywhere in the app
- Group list order is now consistent between the main view and Settings
- Fixed an issue where deleting a group would remove it twice from storage