### PR TITLE
feat: add option to always show search bar

### DIFF
--- a/app/src/main/java/com/rama/mako/activities/MainActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/MainActivity.kt
@@ -12,6 +12,7 @@ import android.os.Handler
 import android.os.Looper
 import android.view.HapticFeedbackConstants
 import android.view.View
+import android.view.WindowManager
 import android.view.animation.OvershootInterpolator
 import android.widget.ListView
 import android.widget.TextView
@@ -26,7 +27,6 @@ import com.rama.mako.managers.AppListManager
 import com.rama.mako.managers.AppsProvider
 import com.rama.mako.managers.BatteryManager
 import com.rama.mako.managers.ClockManager
-import com.rama.mako.managers.FontManager
 import com.rama.mako.managers.HomeBackgroundManager
 import com.rama.mako.managers.PrefsManager
 
@@ -349,11 +349,12 @@ class MainActivity : CsActivity() {
 
     private fun applyHomeBackground(force: Boolean = false) {
         val mode = prefs.getHomeBackgroundMode()
-        val wallpaperSignature = if (homeBackgroundManager.shouldTrackWallpaperChangesForMode(mode)) {
-            homeBackgroundManager.getWallpaperSignature()
-        } else {
-            null
-        }
+        val wallpaperSignature =
+            if (homeBackgroundManager.shouldTrackWallpaperChangesForMode(mode)) {
+                homeBackgroundManager.getWallpaperSignature()
+            } else {
+                null
+            }
 
         if (!force && mode == lastAppliedBackgroundMode && wallpaperSignature == lastAppliedWallpaperSignature) {
             return

--- a/app/src/main/java/com/rama/mako/activities/MainActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/MainActivity.kt
@@ -9,14 +9,12 @@ import android.os.Handler
 import android.os.Looper
 import android.view.HapticFeedbackConstants
 import android.view.View
-import android.view.WindowManager
 import android.view.animation.OvershootInterpolator
 import android.widget.ListView
 import android.widget.TextView
 import android.widget.EditText
 import android.widget.FrameLayout
 import android.widget.LinearLayout
-import android.widget.ScrollView
 import android.widget.Toast
 import android.window.OnBackInvokedCallback
 import com.rama.mako.CsActivity
@@ -25,9 +23,7 @@ import com.rama.mako.managers.AppListManager
 import com.rama.mako.managers.AppsProvider
 import com.rama.mako.managers.BatteryManager
 import com.rama.mako.managers.ClockManager
-import com.rama.mako.managers.FontManager
 import com.rama.mako.managers.PrefsManager
-import com.rama.mako.widgets.WdButton
 
 class MainActivity : CsActivity() {
 
@@ -46,6 +42,7 @@ class MainActivity : CsActivity() {
     private lateinit var searchField: EditText
     private lateinit var searchIcon: FrameLayout
     private lateinit var clearBtn: FrameLayout
+    private var isSearchBarAlwaysVisible = false
 
     private var backCallback: OnBackInvokedCallback? = null
     private var isSearchExpanded = false
@@ -90,7 +87,7 @@ class MainActivity : CsActivity() {
             listView,
             appsProvider
         ) {
-            if (isSearchExpanded) {
+            if (isSearchExpanded && !isSearchBarAlwaysVisible) {
                 collapseSearch()
             }
         }
@@ -111,11 +108,18 @@ class MainActivity : CsActivity() {
     private fun setupBackHandling() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             backCallback = OnBackInvokedCallback {
+                // If search is always visible, loose focus and collapse keyboard
+                if (isSearchBarAlwaysVisible) {
+                    searchField.clearFocus()
+                    val imm =
+                        getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as android.view.inputmethod.InputMethodManager
+                    imm.hideSoftInputFromWindow(searchField.windowToken, 0)
+                }
                 // If search is expanded, collapse it; otherwise consume back to prevent launcher restart
-                if (isSearchExpanded) {
+                else if (isSearchExpanded) {
                     collapseSearch()
                 }
-                // If search is not expanded, do nothing (consume back to keep launcher open)
+                // Else, do nothing (consume back to keep launcher open)
             }
             onBackInvokedDispatcher.registerOnBackInvokedCallback(
                 android.window.OnBackInvokedDispatcher.PRIORITY_OVERLAY,
@@ -186,7 +190,8 @@ class MainActivity : CsActivity() {
 
         // Show field
         searchField.visibility = View.VISIBLE
-        searchField.requestFocus()
+        if (!isSearchBarAlwaysVisible)
+            searchField.requestFocus()
 
         val scaleX = ObjectAnimator.ofFloat(searchField, "scaleX", 0.8f, 1f)
         val scaleY = ObjectAnimator.ofFloat(searchField, "scaleY", 0.8f, 1f)
@@ -234,6 +239,9 @@ class MainActivity : CsActivity() {
         syncSettings()
         appListManager.refresh()
         batteryManager.forceUpdate()
+
+        if (isSearchBarAlwaysVisible)
+            expandSearch()
     }
 
     override fun onDestroy() {
@@ -253,16 +261,25 @@ class MainActivity : CsActivity() {
 
     override fun onBackPressed() {
         // Handle back for below Android 12
-        if (isSearchExpanded) {
+        // If search is always visible, loose focus and collapse keyboard
+        if (isSearchBarAlwaysVisible) {
+            searchField.clearFocus()
+            val imm =
+                getSystemService(android.content.Context.INPUT_METHOD_SERVICE) as android.view.inputmethod.InputMethodManager
+            imm.hideSoftInputFromWindow(searchField.windowToken, 0)
+        }
+        // If search is expanded, collapse it; otherwise consume back to prevent launcher restart
+        else if (isSearchExpanded) {
             collapseSearch()
         }
-        // Otherwise consume back to prevent launcher from restarting
+        // Else, do nothing (consume back to keep launcher open)
     }
 
     // --- Settings sync (row visibility only) ---
     private fun syncSettings() {
         val searchVisible = prefs.isSearchVisible()
 
+        isSearchBarAlwaysVisible = prefs.isSearchBarAlwaysVisible()
         timeText.visibility =
             if (prefs.getClockFormat() != PrefsManager.ClockFormat.NONE) View.VISIBLE else View.GONE
         findViewById<View>(R.id.date_row).visibility =
@@ -272,7 +289,7 @@ class MainActivity : CsActivity() {
         findViewById<View>(R.id.searchbar).visibility =
             if (searchVisible) View.VISIBLE else View.GONE
         searchIcon.visibility =
-            if (searchVisible) View.VISIBLE else View.GONE
+            if (searchVisible && !isSearchBarAlwaysVisible) View.VISIBLE else View.GONE
     }
 
     // --- Open system clock safely ---

--- a/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
+++ b/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
@@ -12,7 +12,8 @@ class SettingsCheckboxController(private val activity: SettingsActivity) {
 
     fun setup() {
         bindWdCheckbox(R.id.show_date, PrefKeys.DATE_VISIBLE, false, listOf(R.id.show_year_day))
-        bindWdCheckbox(R.id.show_search, PrefKeys.APPS_SEARCH, false)
+        bindWdCheckbox(R.id.show_search, PrefKeys.APPS_SEARCH, false, dependentViewIds = listOf(R.id.always_show_search))
+        bindWdCheckbox(R.id.always_show_search, PrefKeys.APPS_ALWAYS_SEARCH_BAR, false)
         bindWdCheckbox(
             R.id.show_group_header,
             PrefKeys.GROUPS_HEADERS,

--- a/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
+++ b/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
@@ -12,8 +12,13 @@ class SettingsCheckboxController(private val activity: SettingsActivity) {
 
     fun setup() {
         bindWdCheckbox(R.id.show_date, PrefKeys.DATE_VISIBLE, false, listOf(R.id.show_year_day))
-        bindWdCheckbox(R.id.show_search, PrefKeys.APPS_SEARCH, false, dependentViewIds = listOf(R.id.always_show_search))
-        bindWdCheckbox(R.id.always_show_search, PrefKeys.APPS_ALWAYS_SEARCH_BAR, false)
+        bindWdCheckbox(
+            R.id.show_search,
+            PrefKeys.APPS_SEARCH,
+            false,
+            dependentViewIds = listOf(R.id.always_show_search)
+        )
+        bindWdCheckbox(R.id.always_show_search, PrefKeys.APPS_SEARCH_ALWAYS_VISIBLE, false)
         bindWdCheckbox(
             R.id.show_group_header,
             PrefKeys.GROUPS_HEADERS,

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -37,6 +37,7 @@ class PrefsManager private constructor(context: Context) {
 
     object PrefKeys {
         const val APPS_SEARCH = "apps:search"
+        const val APPS_ALWAYS_SEARCH_BAR = "apps:always_search_bar"
         const val APPS_ICONS = "apps:icons"
         const val APPS_ICON_SOURCE = "apps:icon_source"
         const val APPS_ICON_PACK_PACKAGE = "apps:icon_pack_package"
@@ -256,6 +257,9 @@ class PrefsManager private constructor(context: Context) {
 
     fun isSearchVisible(): Boolean =
         prefs.getBoolean(PrefKeys.APPS_SEARCH, false)
+
+    fun isSearchBarAlwaysVisible(): Boolean =
+        prefs.getBoolean(PrefKeys.APPS_ALWAYS_SEARCH_BAR, false)
 
     fun hasIconsVisible(): Boolean =
         getIconSource() != IconSource.NONE

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -37,7 +37,7 @@ class PrefsManager private constructor(context: Context) {
 
     object PrefKeys {
         const val APPS_SEARCH = "apps:search"
-        const val APPS_ALWAYS_SEARCH_BAR = "apps:always_search_bar"
+        const val APPS_SEARCH_ALWAYS_VISIBLE = "apps:search:always_visible"
         const val APPS_ICONS = "apps:icons"
         const val APPS_ICON_SOURCE = "apps:icon_source"
         const val APPS_ICON_PACK_PACKAGE = "apps:icon_pack_package"
@@ -270,7 +270,7 @@ class PrefsManager private constructor(context: Context) {
         prefs.getBoolean(PrefKeys.APPS_SEARCH, false)
 
     fun isSearchBarAlwaysVisible(): Boolean =
-        prefs.getBoolean(PrefKeys.APPS_ALWAYS_SEARCH_BAR, false)
+        prefs.getBoolean(PrefKeys.APPS_SEARCH_ALWAYS_VISIBLE, false)
 
     fun hasIconsVisible(): Boolean =
         getIconSource() != IconSource.NONE

--- a/app/src/main/res/layout/view_settings.xml
+++ b/app/src/main/res/layout/view_settings.xml
@@ -138,6 +138,12 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="@string/show_search_label" />
+
+                <com.rama.mako.widgets.WdCheckbox
+                    android:id="@+id/always_show_search"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:text="@string/always_show_search_bar" />
             </com.rama.mako.widgets.WdCollapsibleSection>
 
             <com.rama.mako.widgets.WdCollapsibleSection

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,4 +165,5 @@
 
     <!-- Dialog :: Pick Icon Pack -->
     <string name="pick_icon_pack_disclaimer">Choose an installed icon pack. If an icon is missing, Mako will use the system icon for that app.</string>
+    <string name="always_show_search_bar">Always show search bar</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -172,5 +172,5 @@
 
     <!-- Dialog :: Pick Icon Pack -->
     <string name="pick_icon_pack_disclaimer">Choose an installed icon pack. If an icon is missing, Mako will use the system icon for that app.</string>
-    <string name="always_show_search_bar">Always show search bar</string>
+    <string name="always_show_search_bar">Always visible</string>
 </resources>


### PR DESCRIPTION
I like to have the search bar easier available than clicking the top right corner.
Therefore I Added the option to always show the bottom search bar.
It will always stay open and never collapse.

I set the focus behavior to my liking:
- Do not automatically focus the search bar
- Keyboard opens only when clicking the search bar
- Back button will hide soft keyboard

<img width="392" height="218" alt="image" src="https://github.com/user-attachments/assets/6d6f54aa-5e07-42a6-ac8c-3301c6d75380" />
