### PR TITLE
Fixed bug where searchbar was not reset when opening app

### DIFF
--- a/app/src/main/java/com/rama/mako/activities/MainActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/MainActivity.kt
@@ -110,7 +110,7 @@ class MainActivity : CsActivity() {
             listView,
             appsProvider
         ) {
-            if (isSearchExpanded && !isSearchBarAlwaysVisible) {
+            if (isSearchExpanded) {
                 collapseSearch()
             }
         }


### PR DESCRIPTION
This fixes issue #83  .

The problem can be resolved by collapsing the search bar when opening an app from the list.