### PR TITLE
feat: allow auto group collapse

### DIFF
--- a/app/src/main/java/com/rama/mako/activities/MainActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/MainActivity.kt
@@ -278,7 +278,11 @@ class MainActivity : CsActivity() {
         registerWallpaperReceiverIfNeeded()
         applyHomeBackground(force = true)
         syncSettings()
-        schedulePostResumeRefresh()
+
+        val groupsWereCollapsed = prefs.shouldCollapseGroupsOnHomeFocus() &&
+            appListManager.collapseAllGroups()
+
+        schedulePostResumeRefresh(skipAppListRefresh = groupsWereCollapsed)
 
         if (isSearchBarAlwaysVisible)
             expandSearch()
@@ -424,12 +428,12 @@ class MainActivity : CsActivity() {
         lastAppliedTheme = theme
     }
 
-    private fun schedulePostResumeRefresh() {
+    private fun schedulePostResumeRefresh(skipAppListRefresh: Boolean = false) {
         clearPendingResumeRefresh()
 
         resumeRefreshRunnable = Runnable {
             if (isFinishing || isDestroyed) return@Runnable
-            appListManager.refresh()
+            if (!skipAppListRefresh) appListManager.refresh()
             batteryManager.forceUpdate()
         }
 

--- a/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
+++ b/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
@@ -31,13 +31,40 @@ class SettingsCheckboxController(private val activity: SettingsActivity) {
             listOf(R.id.always_show_search)
         )
         bindWdCheckbox(R.id.always_show_search, FileKeys.APPS_SEARCH_ALWAYS_VISIBLE, false)
+
+        val showGroupHeader = activity.findViewById<WdCheckbox>(R.id.show_group_header)
+        val hasCollapsibleGroups = activity.findViewById<WdCheckbox>(R.id.has_collapsible_groups)
+        val collapseOnHomeFocus = activity.findViewById<WdCheckbox>(R.id.collapse_groups_on_home_focus)
+
+        fun updateCollapseOnHomeVisibility() {
+            collapseOnHomeFocus.visibility =
+                if (showGroupHeader.isChecked() && hasCollapsibleGroups.isChecked()) {
+                    View.VISIBLE
+                } else {
+                    View.GONE
+                }
+        }
+
         bindWdCheckbox(
             R.id.show_group_header,
             FileKeys.GROUPS_HEADERS,
             false,
-            listOf(R.id.has_collapsible_groups)
+            listOf(R.id.has_collapsible_groups),
+            onChange = { updateCollapseOnHomeVisibility() }
         )
-        bindWdCheckbox(R.id.has_collapsible_groups, FileKeys.GROUPS_COLLAPSIBLE, false)
+        bindWdCheckbox(
+            R.id.has_collapsible_groups,
+            FileKeys.GROUPS_COLLAPSIBLE,
+            false,
+            onChange = { updateCollapseOnHomeVisibility() }
+        )
+        bindWdCheckbox(
+            R.id.collapse_groups_on_home_focus,
+            FileKeys.GROUPS_COLLAPSE_ON_HOME_FOCUS,
+            false
+        )
+
+        updateCollapseOnHomeVisibility()
         bindWdCheckbox(R.id.show_year_day, FileKeys.DATE_YEAR_DAY, false)
         bindWdCheckbox(
             R.id.show_battery,

--- a/app/src/main/java/com/rama/mako/managers/AppListManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/AppListManager.kt
@@ -42,6 +42,7 @@ class AppListManager(
 
     private val prefs = PrefsManager.getInstance(context)
     private val iconManager = IconManager(context, appsProvider)
+    private val groupsManager = GroupsManager(context, appsProvider)
     private val items = mutableListOf<ListItem>()
     private lateinit var adapter: ArrayAdapter<ListItem>
     private var allAppsCache: List<AppsProvider.AppEntry> = emptyList()
@@ -88,6 +89,26 @@ class AppListManager(
         adapter.notifyDataSetChanged()
     }
 
+    fun collapseAllGroups(): Boolean {
+        if (!prefs.hasGroupHeaders() || !prefs.hasCollapsibleGroups()) return false
+
+        val expandedIds = getAllGroupIds().filter { prefs.isGroupExpanded(it) }
+        if (expandedIds.isEmpty()) return false
+
+        prefs.setGroupsExpanded(expandedIds.toSet(), false)
+        refresh()
+        return true
+    }
+
+    private fun getAllGroupIds(): List<String> {
+        val knownGroupIds = groupsManager.getGroupIds()
+        val appGroupIds = allAppsCache.map { app ->
+            prefs.getAppGroupId(app.packageName, app.userHandle) ?: PrefsManager.SystemIds.UNGROUPED
+        }.distinct()
+        val unknownGroupIds = appGroupIds.filter { it !in knownGroupIds }
+        return (knownGroupIds + unknownGroupIds).distinct()
+    }
+
     private fun updateAppsCache() {
         allAppsCache = appsProvider.getAll()
         searchableNameCache.clear()
@@ -97,9 +118,6 @@ class AppListManager(
     private fun buildItems() {
         val allApps = allAppsCache
 
-        // Get all known group IDs
-        val groupIds = GroupsManager(context, appsProvider).getGroupIds()
-
         // Map apps by groupId (NOT label)
         val groupedMap = allApps.groupBy { app ->
             prefs.getAppGroupId(app.packageName, app.userHandle) ?: PrefsManager.SystemIds.UNGROUPED
@@ -107,11 +125,7 @@ class AppListManager(
 
         items.clear()
 
-        // Include unknown groupIds (apps pointing to deleted groups)
-        val unknownGroupIds = groupedMap.keys.filter { it !in groupIds }
-        val allGroupIds = (groupIds + unknownGroupIds).distinct()
-
-        allGroupIds.forEach { groupId ->
+        getAllGroupIds().forEach { groupId ->
 
             val apps = groupedMap[groupId] ?: return@forEach
 
@@ -315,18 +329,12 @@ class AppListManager(
 
         val allApps = allAppsCache
 
-        // All known group IDs
-        val groupIds = GroupsManager(context, appsProvider).getGroupIds()
-
         // Group by ID
         val groupedMap = allApps.groupBy { app ->
             prefs.getAppGroupId(app.packageName, app.userHandle) ?: PrefsManager.SystemIds.UNGROUPED
         }
 
-        // Handle unknown groups (apps pointing to deleted groups)
-        val unknownGroupIds = groupedMap.keys.filter { it !in groupIds }
-        val allGroupIds = (groupIds + unknownGroupIds)
-            .distinct()
+        val allGroupIds = getAllGroupIds()
             .sortedBy { prefs.getGroupLabel(it).lowercase(Locale.ROOT) }
 
         allGroupIds.forEach { groupId ->
@@ -501,10 +509,7 @@ class AppListManager(
                 prefs.getAppGroupId(pkg, app.userHandle) ?: PrefsManager.SystemIds.UNGROUPED
 
             // All group IDs (include ungrouped)
-            val groupIds = GroupsManager(
-                context,
-                appsProvider
-            ).getGroupIds()
+            val groupIds = groupsManager.getGroupIds()
 
             groupIds.forEachIndexed { index, groupId ->
                 val isLast = index == groupIds.lastIndex
@@ -638,7 +643,7 @@ class AppListManager(
             container.removeAllViews()
             val radioGroup = RadioGroup(context)
 
-            val groupIds = GroupsManager(context, appsProvider).getGroupIds()
+            val groupIds = groupsManager.getGroupIds()
 
             groupIds.forEachIndexed { index, groupId ->
                 val isLast = index == groupIds.lastIndex

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -31,6 +31,7 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
         const val GROUPS_IDS = "groups:ids"
         const val GROUPS_HEADERS = "groups:headers"
         const val GROUPS_COLLAPSIBLE = "groups:collapsible"
+        const val GROUPS_COLLAPSE_ON_HOME_FOCUS = "groups:collapse_on_home_focus"
         const val DATE_VISIBLE = "date:visible"
         const val DATE_YEAR_DAY = "date:year_day"
         const val BATTERY_VISIBLE = "battery:visible"
@@ -157,6 +158,7 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
 
         editor.putBoolean(FileKeys.GROUPS_HEADERS, true)
         editor.putBoolean(FileKeys.GROUPS_COLLAPSIBLE, true)
+        editor.putBoolean(FileKeys.GROUPS_COLLAPSE_ON_HOME_FOCUS, false)
 
         editor.putBoolean(FileKeys.SECURITY_KEYPAD_VISIBLE, false)
         editor.putBoolean(FileKeys.SECURITY_KEYPAD_RANDOMIZED, true)
@@ -268,6 +270,12 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
     fun setGroupExpanded(id: String, value: Boolean) =
         prefs.edit().putBoolean(FileKeys.GROUP_EXPANDED(id), value).apply()
 
+    fun setGroupsExpanded(ids: Set<String>, expanded: Boolean) {
+        val editor = prefs.edit()
+        ids.forEach { editor.putBoolean(FileKeys.GROUP_EXPANDED(it), expanded) }
+        editor.apply()
+    }
+
     fun hasGroupOrder(id: String): Boolean =
         prefs.contains(FileKeys.GROUP_ORDER(id))
 
@@ -323,6 +331,9 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
 
     fun hasCollapsibleGroups(): Boolean =
         prefs.getBoolean(FileKeys.GROUPS_COLLAPSIBLE, false)
+
+    fun shouldCollapseGroupsOnHomeFocus(): Boolean =
+        prefs.getBoolean(FileKeys.GROUPS_COLLAPSE_ON_HOME_FOCUS, false)
 
     fun isDoubleTapToSleepEnabled(): Boolean =
         prefs.getBoolean(FileKeys.HOME_DOUBLE_TAP_SLEEP, false)

--- a/app/src/main/res/layout/view_settings.xml
+++ b/app/src/main/res/layout/view_settings.xml
@@ -137,6 +137,11 @@
                     android:text="@string/checkbox_has_collapsible_groups"
                     style="@style/Checkbox" />
 
+                <com.rama.bohio.widgets.WdCheckbox
+                    android:id="@+id/collapse_groups_on_home_focus"
+                    android:text="@string/checkbox_collapse_groups_on_home_focus"
+                    style="@style/Checkbox" />
+
                 <View style="@style/Separator" />
 
                 <LinearLayout

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -101,6 +101,7 @@
     <string name="checkbox_show_battery_charge_status">Ladestatus anzeigen</string>
     <string name="checkbox_show_ungrouped_apps">Zeige nicht gruppierte Apps an</string>
     <string name="checkbox_has_collapsible_groups">Minimieren von Gruppen zulassen</string>
+    <string name="checkbox_collapse_groups_on_home_focus">Gruppen beim Zurückkehren einklappen</string>
     <string name="checkbox_show_search">Suchleiste anzeigen</string>
     <string name="checkbox_show_battery">Ladestand anzeigen</string>
     <string name="checkbox_show_system_bar">Systemleiste anzeigen</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -101,6 +101,7 @@
     <string name="checkbox_show_battery_charge_status">Pil şarj durumunu göster</string>
     <string name="checkbox_show_ungrouped_apps">Gruplanmamış uygulamaları göster</string>
     <string name="checkbox_has_collapsible_groups">Grupların daraltılmasına izin ver</string>
+    <string name="checkbox_collapse_groups_on_home_focus">Ana ekrana dönünce grupları daralt</string>
     <string name="checkbox_show_search">Arama çubuğunu göster</string>
     <string name="checkbox_show_battery">Pili göster</string>
     <string name="checkbox_show_system_bar">Sistem çubuğunu göster</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,6 +103,7 @@
     <string name="checkbox_show_battery_charge_status">Show battery charge status</string>
     <string name="checkbox_show_ungrouped_apps">Show ungrouped apps</string>
     <string name="checkbox_has_collapsible_groups">Allow collapsing groups</string>
+    <string name="checkbox_collapse_groups_on_home_focus">Collapse groups when returning home</string>
     <string name="checkbox_show_search">Show search bar</string>
     <string name="checkbox_show_battery">Show battery</string>
     <string name="checkbox_show_system_bar">Show system bar</string>


### PR DESCRIPTION
This implements enhancement issue: https://github.com/rama-io/mako/issues/153

I extracted a function in order to not duplicate getting all the groups again, can revert that change if needed