### PR TITLE
fix: use accessibilty method for double tap to lock in Android 17

### DIFF
--- a/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
+++ b/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
@@ -175,6 +175,10 @@ class SettingsCheckboxController(private val activity: SettingsActivity) {
         val adminRadio = activity.findViewById<RadioButton>(R.id.lock_method_device_admin)
         val accessibilityRadio = activity.findViewById<RadioButton>(R.id.lock_method_accessibility)
 
+        if (lockManager.isAccessibilitySupported()) {
+            (adminRadio.parent as? View)?.visibility = View.GONE
+        }
+
         fun onMethodSelected(method: String) {
             if (isSyncingLockMethodGroup) return
             if (prefs.getDoubleTapLockMethod() == method) return

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -330,9 +330,16 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
     fun setDoubleTapToSleepEnabled(enabled: Boolean) =
         prefs.edit().putBoolean(FileKeys.HOME_DOUBLE_TAP_SLEEP, enabled).apply()
 
-    fun getDoubleTapLockMethod(): String =
-        prefs.getString(FileKeys.HOME_DOUBLE_TAP_LOCK_METHOD, defaultDoubleTapLockMethod)
-            ?: defaultDoubleTapLockMethod
+    fun getDoubleTapLockMethod(): String {
+        val stored = prefs.getString(FileKeys.HOME_DOUBLE_TAP_LOCK_METHOD, null)
+        return when {
+            stored == null -> defaultDoubleTapLockMethod
+            Build.VERSION.SDK_INT >= Build.VERSION_CODES.P &&
+                    stored == DoubleTapLockManager.METHOD_DEVICE_ADMIN ->
+                DoubleTapLockManager.METHOD_ACCESSIBILITY
+            else -> stored
+        }
+    }
 
     private val defaultDoubleTapLockMethod: String
         get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {

--- a/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
+++ b/app/src/main/java/com/rama/mako/managers/PrefsManager.kt
@@ -2,6 +2,7 @@ package com.rama.mako.managers
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Build
 import android.os.UserHandle
 import com.rama.bohio.util.IdUtils
 import androidx.security.crypto.EncryptedSharedPreferences
@@ -134,7 +135,7 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
 
         editor.putString(FileKeys.HOME_BACKGROUND_MODE, BackgroundMode.DEFAULT)
         editor.putBoolean(FileKeys.HOME_DOUBLE_TAP_SLEEP, false)
-        editor.putString(FileKeys.HOME_DOUBLE_TAP_LOCK_METHOD, "device_admin")
+        editor.putString(FileKeys.HOME_DOUBLE_TAP_LOCK_METHOD, defaultDoubleTapLockMethod)
         editor.putInt(FileKeys.HOME_BACKGROUND_MODE_SCREEN_OPACITY_STRENGTH, 9)
 
         editor.putBoolean(FileKeys.BATTERY_VISIBLE, true)
@@ -330,7 +331,15 @@ class PrefsManager private constructor(context: Context) : BohioPrefsManager(con
         prefs.edit().putBoolean(FileKeys.HOME_DOUBLE_TAP_SLEEP, enabled).apply()
 
     fun getDoubleTapLockMethod(): String =
-        prefs.getString(FileKeys.HOME_DOUBLE_TAP_LOCK_METHOD, "device_admin") ?: "device_admin"
+        prefs.getString(FileKeys.HOME_DOUBLE_TAP_LOCK_METHOD, defaultDoubleTapLockMethod)
+            ?: defaultDoubleTapLockMethod
+
+    private val defaultDoubleTapLockMethod: String
+        get() = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            DoubleTapLockManager.METHOD_ACCESSIBILITY
+        } else {
+            DoubleTapLockManager.METHOD_DEVICE_ADMIN
+        }
 
     fun setDoubleTapLockMethod(method: String) =
         prefs.edit().putString(FileKeys.HOME_DOUBLE_TAP_LOCK_METHOD, method).apply()


### PR DESCRIPTION
This fixes issue [#157](https://github.com/rama-io/mako/issues/157)

It seems to be related to the device admin force lock policies being deprecated
In my opinion this means that the "Device Admin" lock method is unusable on Android 17 in any case and shouldn't be an option any more from 17 onwards