### PR TITLE
fix: handle regression collapsing groups when pressing back on search field

### DIFF
--- a/app/src/main/java/com/rama/mako/activities/MainActivity.kt
+++ b/app/src/main/java/com/rama/mako/activities/MainActivity.kt
@@ -198,9 +198,13 @@ class MainActivity : CsActivity() {
                 if (appListManager.handleBackPress()) return
 
                 if (isSearchBarAlwaysVisible) {
-                    searchField.clearFocus()
+                    if (searchField.hasFocus()) {
+                        searchField.clearFocus()
+                        return
+                    }
                 } else if (isSearchExpanded) {
                     collapseSearch()
+                    return
                 }
 
                 if (prefs.getBoolean(FileKeys.GROUPS_COLLAPSIBLE, true)) {


### PR DESCRIPTION
This fixes [https://github.com/rama-io/mako/issues/184](#184) initially reported on discord