### PR TITLE
chore: lock settings pin enhancements

### DIFF
--- a/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
+++ b/app/src/main/java/com/rama/mako/activities/settings/SettingsCheckboxController.kt
@@ -82,7 +82,10 @@ class SettingsCheckboxController(private val activity: SettingsActivity) {
             R.id.lock_settings,
             FileKeys.SECURITY_KEYPAD_VISIBLE,
             false,
-            listOf(R.id.randomized_keypad, R.id.pin_field)
+            listOf(R.id.randomized_keypad, R.id.pin_field),
+            onChange = { checked ->
+                if (!checked) prefs.clearPin()
+            }
         )
         bindWdCheckbox(
             R.id.randomized_keypad,

--- a/app/src/main/java/com/rama/mako/activities/settings/SettingsPinController.kt
+++ b/app/src/main/java/com/rama/mako/activities/settings/SettingsPinController.kt
@@ -29,17 +29,26 @@ class SettingsPinController(private val activity: SettingsActivity) {
         val pinField = activity.findViewById<WdPinField>(R.id.pin_field_widget)
 
         pinField.onPinSaved = { pin ->
-            if (pin.length >= 1) {
-                prefs.setPin(pin)
-                android.widget.Toast.makeText(
-                    activity,
-                    activity.getString(R.string.toast_pin_saved),
-                    android.widget.Toast.LENGTH_SHORT
-                ).show()
+            if (pin.isNotEmpty()) {
+                android.app.AlertDialog.Builder(activity)
+                    .setTitle(R.string.dialog_save_pin_title)
+                    .setMessage(R.string.dialog_save_pin_warning)
+                    .setNegativeButton(android.R.string.cancel, null)
+                    .setPositiveButton(android.R.string.ok) { _, _ ->
+                        prefs.setPin(pin)
+                        android.widget.Toast.makeText(
+                            activity,
+                            activity.getString(R.string.toast_pin_saved),
+                            android.widget.Toast.LENGTH_SHORT
+                        ).show()
+                    }
+                    .show()
             } else {
+                prefs.clearPin()
+                activity.findViewById<WdCheckbox>(R.id.lock_settings).setChecked(false)
                 android.widget.Toast.makeText(
                     activity,
-                    activity.getString(R.string.toast_pin_too_short),
+                    activity.getString(R.string.toast_pin_removed),
                     android.widget.Toast.LENGTH_SHORT
                 ).show()
             }

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -53,6 +53,8 @@
     <string name="disclaimer_pick_clock_app">Die ausgewählte App wird als Standard-Uhr-Aktion festgelegt. Beim Antippen der Uhr auf dem Startbildschirm wird diese App gestartet.</string>
     <string name="disclaimer_pick_date_app">Die ausgewählte App wird als Standard-Datumsaktion festgelegt. Beim Antippen des Datums auf dem Startbildschirm wird diese App gestartet.</string>
     <string name="disclaimer_pick_icon_pack">Wähle ein installiertes Icon-Paket aus. Bei fehlenden Icons wird Mako das System-Icon für die App verwenden.</string>
+    <string name="dialog_save_pin_title">Diese PIN speichern?</string>
+    <string name="dialog_save_pin_warning">Merke dir diese PIN. Wenn du sie vergisst, musst du möglicherweise die App-Daten von Mako löschen, um wieder auf die Einstellungen zugreifen zu können.</string>
     <string name="easter_eggs_counter">Noch %1$d…</string>
     <string name="easter_eggs_unlock">Kannst du bitte aufhören damit zu spielen xD</string>
     <string name="filepicker_icon_pack_not_selected">Kein Icon-Paket ausgewählt</string>
@@ -107,8 +109,8 @@
     <string name="toast_no_clock_app_found">Keine Uhr-App gefunden</string>
     <string name="toast_no_date_app_found">Keine Datums-App gefunden</string>
     <string name="toast_no_icon_pack_found">Kein kompatibles Icon-Paket gefunden</string>
+    <string name="toast_pin_removed">PIN entfernt und Einstellungen entsperrt</string>
     <string name="toast_pin_saved">PIN gespeichert</string>
-    <string name="toast_pin_too_short">PIN muss mindestens 1 Ziffer lang sein</string>
     <string name="toast_reset_done">Zurücksetzen abgeschlossen</string>
     <string name="toast_reset_failed">Zurücksetzen fehlgeschlagen</string>
     <string name="toast_select_target_group">Wählen Sie eine Zielgruppe aus</string>

--- a/app/src/main/res/values-fi/strings.xml
+++ b/app/src/main/res/values-fi/strings.xml
@@ -53,6 +53,8 @@
     <string name="disclaimer_pick_clock_app">Valitse sovellus, joka avataan, kun kosketat kellonaikaa kotinäytössä.</string>
     <string name="disclaimer_pick_date_app">Valitse sovellus, joka avataan, kun kosketat päivämäärää kotinäytössä.</string>
     <string name="disclaimer_pick_icon_pack">Valitse kuvakkeiden tyyli. Jos valitussa tyylissä ei ole jollekin sovellukselle kuvaketta, käytetään sovelluksen normaalia kuvaketta.</string>
+    <string name="dialog_save_pin_title">Tallennetaanko tämä PIN-koodi?</string>
+    <string name="dialog_save_pin_warning">Varmista, että muistat sen. Jos unohdat PIN-koodin, sinun on ehkä tyhjennettävä Makon sovellustiedot päästäksesi jälleen asetuksiin.</string>
     <string name="easter_eggs_counter">%1$d lisää…</string>
     <string name="easter_eggs_unlock">Lopeta se leikkiminen xD</string>
     <string name="filepicker_icon_pack_not_selected">Kuvakepakettia ei ole valittu</string>
@@ -107,8 +109,8 @@
     <string name="toast_no_clock_app_found">Ei kellosovellusta</string>
     <string name="toast_no_date_app_found">Ei kalenterisovellusta</string>
     <string name="toast_no_icon_pack_found">Sopivaa kuvakepakettia ei löytynyt</string>
+    <string name="toast_pin_removed">PIN-koodi poistettu ja asetusten lukitus avattu</string>
     <string name="toast_pin_saved">PIN tallennettu</string>
-    <string name="toast_pin_too_short">Aseta vähintään yksi numero</string>
     <string name="toast_reset_done">Nollaus onnistui</string>
     <string name="toast_reset_failed">Nollaus epäonnistui</string>
     <string name="toast_select_target_group">Valitse ryhmä</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -53,6 +53,8 @@
     <string name="disclaimer_pick_clock_app">Kapag pumili ka ng app dito, ito ang magiging default na aksyon ng orasan. Kapag na-tap mo ang orasan sa iyong home screen, ilulunsad ang app na ito.</string>
     <string name="disclaimer_pick_date_app">Kapag pumili ka ng app dito, ito ang magiging default na aksyon ng petsa. Kapag na-tap mo ang petsa sa iyong home screen, ilulunsad ang app na ito.</string>
     <string name="disclaimer_pick_icon_pack">Pumili ng naka-install na icon pack. Kung may kulang na icon, gagamitin ng Mako ang system icon para sa app na iyon.</string>
+    <string name="dialog_save_pin_title">I-save ang PIN na ito?</string>
+    <string name="dialog_save_pin_warning">Siguraduhing matatandaan mo ito. Kapag nakalimutan mo ang iyong PIN, maaaring kailanganin mong i-clear ang data ng Mako app para muling ma-access ang settings.</string>
     <string name="easter_eggs_counter">%1$d pa…</string>
     <string name="easter_eggs_unlock">Pwede bang tumigil ka sa paglalaro dito xD</string>
     <string name="filepicker_icon_pack_not_selected">Walang napiling icon pack</string>
@@ -107,8 +109,8 @@
     <string name="toast_no_clock_app_found">Walang nakitang app ng orasan</string>
     <string name="toast_no_date_app_found">Walang nakitang app ng petsa</string>
     <string name="toast_no_icon_pack_found">Walang nakitang compatible na icon pack</string>
+    <string name="toast_pin_removed">Tinanggal ang PIN at na-unlock ang settings</string>
     <string name="toast_pin_saved">Na-save ang PIN</string>
-    <string name="toast_pin_too_short">Ang PIN ay dapat may hindi bababa sa 1 na digit</string>
     <string name="toast_reset_done">Tapos na ang pag-reset</string>
     <string name="toast_reset_failed">Nabigo ang pag-reset</string>
     <string name="toast_select_target_group">Pumili ng target na grupo</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -53,6 +53,8 @@
     <string name="disclaimer_pick_clock_app">Sélectionner une application ici la définira comme action horloge par défaut. Lorsque vous tapotez l\'horloge sur l\'écran d\'accueil, cette application sera lancée.</string>
     <string name="disclaimer_pick_date_app">Sélectionner une application ici la définira comme action date par défaut. Lorsque vous tapotez la date sur l\'écran d\'accueil, cette application sera lancée.</string>
     <string name="disclaimer_pick_icon_pack">Choisissez un pack d\'icônes installé. Si une icône est manquante, Mako utilisera l\'icône système de l\'application.</string>
+    <string name="dialog_save_pin_title">Enregistrer ce code PIN ?</string>
+    <string name="dialog_save_pin_warning">Veillez à vous en souvenir. Si vous oubliez votre code PIN, vous devrez peut-être effacer les données de l\'application Mako pour accéder de nouveau aux paramètres.</string>
     <string name="easter_eggs_counter">Encore %1$d…</string>
     <string name="easter_eggs_unlock">Tu peux arrêter de jouer avec xD</string>
     <string name="filepicker_icon_pack_not_selected">Aucun pack d\'icônes sélectionné</string>
@@ -107,8 +109,8 @@
     <string name="toast_no_clock_app_found">Aucune application horloge trouvée</string>
     <string name="toast_no_date_app_found">Aucune application de date trouvée</string>
     <string name="toast_no_icon_pack_found">Aucun pack d\'icônes compatible trouvé</string>
+    <string name="toast_pin_removed">Code PIN supprimé et paramètres déverrouillés</string>
     <string name="toast_pin_saved">PIN enregistré</string>
-    <string name="toast_pin_too_short">Le PIN doit comporter au moins 1 chiffre</string>
     <string name="toast_reset_done">Réinitialisation effectuée</string>
     <string name="toast_reset_failed">Échec de la réinitialisation</string>
     <string name="toast_select_target_group">Sélectionnez un groupe cible</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -53,6 +53,8 @@
     <string name="disclaimer_pick_clock_app">Selecionar um aplicativo aqui irá defini-lo como sua ação de toque padrão. Quando você toca no relógio na tela inicial, este aplicativo será iniciado.</string>
     <string name="disclaimer_pick_date_app">Selecionar um aplicativo aqui irá defini-lo como sua ação de data padrão. Quando você toca na data na tela inicial, este aplicativo será iniciado.</string>
     <string name="disclaimer_pick_icon_pack">Escolha um pacote de ícones instalado. Se um ícone estiver ausente, o Mako usará o ícone do sistema para esse aplicativo.</string>
+    <string name="dialog_save_pin_title">Salvar este PIN?</string>
+    <string name="dialog_save_pin_warning">Memorize este PIN. Se você esquecê-lo, talvez seja necessário limpar os dados do app Mako para recuperar o acesso às configurações.</string>
     <string name="easter_eggs_counter">%1$d mais…</string>
     <string name="easter_eggs_unlock">Pode, por favor, parar de brincar com ele xD</string>
     <string name="filepicker_icon_pack_not_selected">Nenhum pacote de ícones selecionado</string>
@@ -107,8 +109,8 @@
     <string name="toast_no_clock_app_found">Nenhum aplicativo de relógio encontrado</string>
     <string name="toast_no_date_app_found">Nenhum aplicativo de data encontrado</string>
     <string name="toast_no_icon_pack_found">Nenhum pacote de ícones compatível encontrado</string>
+    <string name="toast_pin_removed">PIN removido e configurações desbloqueadas</string>
     <string name="toast_pin_saved">PIN salvo</string>
-    <string name="toast_pin_too_short">PIN deve ser de pelo menos 1 dígito</string>
     <string name="toast_reset_done">Redefinição feita</string>
     <string name="toast_reset_failed">Redefinir falhou</string>
     <string name="toast_select_target_group">Selecione um grupo de destino</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -53,6 +53,8 @@
     <string name="disclaimer_pick_clock_app">Buradan bir uygulama seçmek, onu varsayılan saat eylemi olarak ayarlar. Ana ekranınızdaki saate dokunduğunuzda bu uygulama açılır.</string>
     <string name="disclaimer_pick_date_app">Buradan bir uygulama seçmek, onu varsayılan tarih eylemi olarak ayarlar. Ana ekranınızdaki tarihe dokunduğunuzda bu uygulama açılır.</string>
     <string name="disclaimer_pick_icon_pack">Yüklü bir ikon paketi seçin. Bir ikon eksikse Mako, o uygulama için sistem ikonunu kullanır.</string>
+    <string name="dialog_save_pin_title">Bu PIN kaydedilsin mi?</string>
+    <string name="dialog_save_pin_warning">Bu PIN\'i hatırladığınızdan emin olun. PIN\'inizi unutursanız ayarlara yeniden erişmek için Mako\'nun uygulama verilerini temizlemeniz gerekebilir.</string>
     <string name="easter_eggs_counter">%1$d kez daha…</string>
     <string name="easter_eggs_unlock">Lütfen bununla oynamayı bırakır mısın xD</string>
     <string name="filepicker_icon_pack_not_selected">İkon paketi seçilmedi</string>
@@ -107,8 +109,8 @@
     <string name="toast_no_clock_app_found">Saat uygulaması bulunamadı</string>
     <string name="toast_no_date_app_found">Tarih uygulaması bulunamadı</string>
     <string name="toast_no_icon_pack_found">Uyumlu ikon paketi bulunamadı</string>
+    <string name="toast_pin_removed">PIN kaldırıldı ve ayarların kilidi açıldı</string>
     <string name="toast_pin_saved">PIN kaydedildi</string>
-    <string name="toast_pin_too_short">PIN en az 1 haneli olmalıdır</string>
     <string name="toast_reset_done">Sıfırlama tamamlandı</string>
     <string name="toast_reset_failed">Sıfırlama başarısız</string>
     <string name="toast_select_target_group">Bir hedef grup seçin</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -53,6 +53,8 @@
     <string name="disclaimer_pick_clock_app">在主屏幕上点击时间，默认打开时钟。在此设置一个应用，点击时钟将会启动该应用。</string>
     <string name="disclaimer_pick_date_app">在主屏幕上点击日期，默认打开日历。在此设置一个应用，点击日期将会启动该应用。</string>
     <string name="disclaimer_pick_icon_pack">选择的图标包如果缺少某个图标,Mako启动器将使用该应用默认的图标。</string>
+    <string name="dialog_save_pin_title">保存此 PIN？</string>
+    <string name="dialog_save_pin_warning">请务必记住此 PIN。如果忘记 PIN，可能需要清除 Mako 的应用数据才能重新访问设置。</string>
     <string name="easter_eggs_counter">%1$d more…</string>
     <string name="easter_eggs_unlock">Can you please stop playing with it xD</string>
     <string name="filepicker_icon_pack_not_selected">未选择图标包</string>
@@ -107,8 +109,8 @@
     <string name="toast_no_clock_app_found">No clock app found</string>
     <string name="toast_no_date_app_found">No date app found</string>
     <string name="toast_no_icon_pack_found">没有安装图标包</string>
+    <string name="toast_pin_removed">PIN 已移除，设置已解锁</string>
     <string name="toast_pin_saved">PIN 已保存</string>
-    <string name="toast_pin_too_short">PIN密码必须至少1位数字</string>
     <string name="toast_reset_done">Reset done</string>
     <string name="toast_reset_failed">Reset failed</string>
     <string name="toast_select_target_group">Select a target group</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -60,6 +60,8 @@
     <string name="disclaimer_pick_clock_app">Selecting an app here will set it as your default clock action. When you tap the clock on your home screen, this app will be launched.</string>
     <string name="disclaimer_pick_date_app">Selecting an app here will set it as your default date action. When you tap the date on your home screen, this app will be launched.</string>
     <string name="disclaimer_pick_icon_pack">Choose an installed icon pack. If an icon is missing, Mako will use the system icon for that app.</string>
+    <string name="dialog_save_pin_title">Save this PIN?</string>
+    <string name="dialog_save_pin_warning">Make sure you remember it. If you forget your PIN, you may need to clear Mako\'s app data to regain access to settings.</string>
     <string name="easter_eggs_counter">%1$d more…</string>
     <string name="easter_eggs_unlock">Can you please stop playing with it xD</string>
     <string name="filepicker_icon_pack_not_selected">No icon pack selected</string>
@@ -114,6 +116,7 @@
     <string name="toast_no_clock_app_found">No clock app found</string>
     <string name="toast_no_date_app_found">No date app found</string>
     <string name="toast_no_icon_pack_found">No compatible icon pack found</string>
+    <string name="toast_pin_removed">PIN removed and settings unlocked</string>
     <string name="toast_pin_saved">PIN saved</string>
     <string name="toast_pin_too_short">PIN must be at least 1 digits</string>
     <string name="toast_reset_done">Reset done</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -118,7 +118,6 @@
     <string name="toast_no_icon_pack_found">No compatible icon pack found</string>
     <string name="toast_pin_removed">PIN removed and settings unlocked</string>
     <string name="toast_pin_saved">PIN saved</string>
-    <string name="toast_pin_too_short">PIN must be at least 1 digits</string>
     <string name="toast_reset_done">Reset done</string>
     <string name="toast_reset_failed">Reset failed</string>
     <string name="toast_select_target_group">Select a target group</string>


### PR DESCRIPTION
- Empty save clears the PIN and unchecks Lock Settings.
- Unchecking Lock Settings clears the PIN.
- Non-empty save shows a confirmation warning before storing the PIN.

@pomboverso @isotjs I think this limits the possible user errors already. Let me know if i should add more to this